### PR TITLE
User is able to select category link and see a category view filtered…

### DIFF
--- a/src/components/ApplicationViews.js
+++ b/src/components/ApplicationViews.js
@@ -36,9 +36,14 @@ const ApplicationViews = (props) => {
             />  
             <Route
                 exact path="/product-categories" render={props => {
-                    return <ProductCategories {...props} />
+                    return <ProductCategories isSingle={false} {...props} />
                 }}
-            />   
+            />
+            <Route
+                path="/producttypes/:product_type_id" render={props => {
+                    return <ProductCategories isSingle={true} {...props} />
+                }}
+            />
         </React.Fragment>
     )
 }

--- a/src/components/product/CategoryDeck.js
+++ b/src/components/product/CategoryDeck.js
@@ -6,13 +6,21 @@ const CategoryDeck = props => {
     const [products, setProducts] = useState([])
 
     const getProducts = () => {
-        const urls = props.category.products.splice(-3, 3)
-
-        return Promise.all(urls.map(mappedUrl => fetch(mappedUrl)))
+        const { isSingle, category } = props;
+        if (category.id && isSingle === false) {
+            const urls = category.products.splice(-3, 3)
+            return Promise.all(urls.map(mappedUrl => fetch(mappedUrl)))
             .then(responses => Promise.all(responses.map(response => response.json())))
             .then(productArr => {
                 setProducts(productArr.reverse())
             })
+        } else if (category.id && isSingle) {
+            return Promise.all(category.products.map(mappedUrl => fetch(mappedUrl)))
+            .then(responses => Promise.all(responses.map(response => response.json())))
+            .then(productArr => {
+                setProducts(productArr.reverse())
+            })
+        }
     }
 
     useEffect(() => {

--- a/src/components/product/ProductCard.js
+++ b/src/components/product/ProductCard.js
@@ -18,7 +18,7 @@ const ProductCard = props => {
 
     useEffect(() => {
         getProductType();
-    }, {})
+    }, [])
 
     return (
         <div className='product-card'>

--- a/src/components/product/ProductCard.js
+++ b/src/components/product/ProductCard.js
@@ -1,12 +1,31 @@
 import React from 'react'
+import dataManager from '../../modules/dataManager'
+import { Link } from "react-router-dom";
+import { useState, useEffect } from 'react';
 
 const ProductCard = props => {
+    const [productType, setProductType] = useState({})
+    const { product } = props;
+    const categoryLink = `/producttypes/${product.product_type_id}`
+
+    const getProductType = () => {
+        return dataManager.get('producttypes', product.product_type_id)
+          .then((productType) => {
+              setProductType(productType);
+          })
+          .catch((err) => console.error('There was an issue getting a product type:', err));
+    }
+
+    useEffect(() => {
+        getProductType();
+    }, {})
 
     return (
         <div className='product-card'>
             <div className='product-card-content'>
-                <img src={props.product.image} width={240} alt='thumbnail' />
-                <h4>{props.product.title}</h4>
+                <img src={product.image} width={240} alt='thumbnail' />
+                <h4>{product.title}</h4>
+                <p>Category: <Link to={categoryLink}>{productType.name}</Link></p>
             </div>
         </div>
     )

--- a/src/components/product/ProductCategories.js
+++ b/src/components/product/ProductCategories.js
@@ -5,28 +5,53 @@ import CategoryDeck from './CategoryDeck'
 const ProductCategories = props => {
 
     const [categories, setCategories] = useState([])
+    const [singleCategory, setSingleCategory] = useState({})
 
     const getCategories = () => {
-        return dataManager.getAll('producttypes')
-        .then(categoryArr => {
-            setCategories(categoryArr)
-        })
+        const { isSingle } = props;
+        if (isSingle) {
+            const { product_type_id } = props.match.params;
+            return dataManager.get('producttypes', product_type_id)
+              .then((category) => {
+                  console.log(category)
+                  setSingleCategory(category)
+              })
+              .catch((err) => console.error('There was an issue getting a single product types:', err))
+        } else {
+            return dataManager.getAll('producttypes')
+            .then(categoryArr => {
+                setCategories(categoryArr)
+            })
+        }
     }
 
     useEffect(() => {
         getCategories();
     }, [])
-
+    const { isSingle } = props;
     return (
         <section className='list-view'>
             <div className='category-decks'>
-                {categories.map(mappedCategory =>
-                <CategoryDeck 
-                    key={mappedCategory.id}
-                    category={mappedCategory}
-                    {...props}
-                />
-                )}
+                { 
+                    isSingle 
+                    ? (
+                        <CategoryDeck 
+                            key={singleCategory.id}
+                            category={singleCategory}
+                            {...props}
+                            isSingle={isSingle}
+                        />
+                    )
+                    : (
+                        categories.map(mappedCategory =>
+                        <CategoryDeck 
+                            key={mappedCategory.id}
+                            category={mappedCategory}
+                            {...props}
+                            isSingle={isSingle}
+                        />)
+                    )
+                }
             </div>
         </section>
     )

--- a/src/components/product/ProductCategories.js
+++ b/src/components/product/ProductCategories.js
@@ -13,7 +13,6 @@ const ProductCategories = props => {
             const { product_type_id } = props.match.params;
             return dataManager.get('producttypes', product_type_id)
               .then((category) => {
-                  console.log(category)
                   setSingleCategory(category)
               })
               .catch((err) => console.error('There was an issue getting a single product types:', err))

--- a/src/index.css
+++ b/src/index.css
@@ -35,3 +35,11 @@ code {
 .product-card {
   margin: 10px;
 }
+
+.product-list {
+  display: flex;
+  flex-flow: row wrap;
+  align-items: center;
+  justify-content: space-evenly;
+  margin-top: 10px;
+}


### PR DESCRIPTION
# Description
At any point in the site when a product card is being displayed, the user will see a link to the product categories page and it will be filtered by the particular type that was clicked.  I also tweaked the styling of the categories deck to be a flexbox.
 
 ## Type of change
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [x] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
 - [ ] This change requires a documentation update
 # Testing Instructions
Please navigate to the all products page and click on the new hyperlinks included on the cards.  You should be directed to a filtered version of the categories page, and see all of the products in that category.  You should also see them displayed as a row (I'm open to change on this).
 # Checklist:
 - [x] My code follows the style guidelines of this project
 - [x] I have performed a self-review of my own code
 - [ ] I have commented my code, particularly in hard-to-understand areas
 - [x] My changes generate no new warnings or errors
 - [x] I have added test instructions that prove my fix is effective or that my feature works