### PR TITLE
Delete payment type

### DIFF
--- a/src/components/account/PayTypeCard.js
+++ b/src/components/account/PayTypeCard.js
@@ -1,0 +1,30 @@
+import React from 'react'
+import dataManager from '../../modules/dataManager'
+
+const PayTypeCard = props => {
+
+    const deletePayType = (id) => {
+        return fetch(`http://localhost:8000/paymenttypes/${id}`, {
+            method: "DELETE",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "Authorization": `Token ${localStorage.getItem("bangazon_token")}`
+            }
+        })
+        .then(toggleToggle)
+    }
+
+    const toggleToggle = () => {
+        props.toggle ? props.setToggle(false) : props.setToggle(true)
+    }
+
+    return (
+        <li>
+            <p>{props.paymentType.merchant_name} {props.paymentType.expiration_date}</p> 
+            <button onClick={() => deletePayType(props.paymentType.id)}>Delete</button>
+        </li>
+    )
+}
+
+export default PayTypeCard

--- a/src/components/account/Profile.js
+++ b/src/components/account/Profile.js
@@ -1,6 +1,7 @@
 import React, {useState, useEffect} from 'react'
 import {createPortal} from 'react-dom'
 import EditProfileForm from './EditProfileForm'
+import PayTypeCard from './PayTypeCard'
 
 const Profile = props => {
     
@@ -47,6 +48,18 @@ const Profile = props => {
 
     const modalDiv = document.getElementById('modal');
 
+    const deletePayType = (id) => {
+        return fetch(`http://localhost:8000/paymenttypes/${id}`, {
+            method: "DELETE",
+            headers: {
+                "Content-Type": "application/json",
+                "Accept": "application/json",
+                "Authorization": `Token ${localStorage.getItem("bangazon_token")}`
+            }
+        })
+        .then(props.getPaymentTypes)
+    }
+
     useEffect(() => {
         getCurrentUser();
     }, [toggle])
@@ -67,7 +80,12 @@ const Profile = props => {
             <h3>Payment Types:</h3>
             <ul>
                 {paymentTypes.map(mappedPayType => {
-                    return <li key={mappedPayType.id}>{mappedPayType.merchant_name} {mappedPayType.expiration_date}</li>
+                    return <PayTypeCard 
+                            key={mappedPayType.id}
+                            paymentType={mappedPayType}
+                            toggle={toggle}
+                            setToggle={setToggle}
+                            />
                 })}
             </ul>
 

--- a/src/modules/dataManager.js
+++ b/src/modules/dataManager.js
@@ -7,7 +7,8 @@ export default {
             method: "GET",
             headers: {
                 "Content-Type": "application/json",
-                "Accept": "application/json"
+                "Accept": "application/json",
+                "Authorization": `Token ${localStorage.getItem("bangazon_token")}`
             }
         })
                 .then(response => response.json())


### PR DESCRIPTION
# Description
Payment types can now be safely deleted. It's a soft delete so orders associated with the payment id should still be searchable

Fixes #8 (https://github.com/nss-cohort-40/bangazon-ecommerce-api-lumberjacks-back/issues/8)
## Type of change
Please delete options that are not relevant.
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Testing Instructions
• `pip install django-safedelete`
• `python manage.py makemigrations ecommerceapi`
• `python manage.py migrate`
• Try deleting a payment method that is connected to a completed order from the profile page.
• Check database to ensure payment type has a delete date attribute in db

# Checklist:
- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] My changes generate no new warnings or errors
- [ ] I have added test instructions that prove my fix is effective or that my feature works